### PR TITLE
dependency update and warning fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ poetry.lock
 .venv/
 .pytest_cache/
 .mypy_cache/
+.vscode
+poetry.toml

--- a/chronocluster/clustering.py
+++ b/chronocluster/clustering.py
@@ -258,7 +258,6 @@ def temporal_pairwise(
                     distances_for_time_slices.append(None)
                     continue
                 pairwise_distances = distance.cdist(f_pts, pts)
-                distances_for_time_slices.append(pairwise_distances)
                 if max_distance is not None:
                     pairwise_distances = pairwise_distances[pairwise_distances <= max_distance]
                 if pairwise_distances.size == 0:

--- a/chronocluster/clustering.py
+++ b/chronocluster/clustering.py
@@ -259,6 +259,12 @@ def temporal_pairwise(
                     continue
                 pairwise_distances = distance.cdist(f_pts, pts)
                 distances_for_time_slices.append(pairwise_distances)
+                if max_distance is not None:
+                    pairwise_distances = pairwise_distances[pairwise_distances <= max_distance]
+                if pairwise_distances.size == 0:
+                    distances_for_time_slices.append(None)
+                else:
+                    distances_for_time_slices.append(pairwise_distances)
             all_distances.append(distances_for_time_slices)
     else:
         for simulation in point_sets:
@@ -268,7 +274,12 @@ def temporal_pairwise(
                     distances_for_time_slices.append(None)
                     continue
                 pairwise_distances = distance.pdist(points)
-                distances_for_time_slices.append(pairwise_distances)
+                if max_distance is not None:
+                    pairwise_distances = pairwise_distances[pairwise_distances <= max_distance]
+                if pairwise_distances.size == 0:
+                    distances_for_time_slices.append(None)
+                else:
+                    distances_for_time_slices.append(pairwise_distances)
             all_distances.append(distances_for_time_slices)
 
     # Calculate max_distance if not provided

--- a/chronocluster/distributions.py
+++ b/chronocluster/distributions.py
@@ -85,7 +85,7 @@ class calrcarbon:
         t_max = t_values[mask].max()
         t_values = np.linspace(t_min, t_max, 10000)
         pdf_values = self._pdf(t_values, c14_mean, c14_err)
-        pdf_values /= np.trapz(pdf_values, t_values)
+        pdf_values /= np.trapezoid(pdf_values, t_values)
         return t_values, pdf_values
 
     def pdf(self, tau, c14_mean=None, c14_err=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ pointpats = "^2.5.1"  # alternative?
 seaborn = "^0.13.2"
 statsmodels = "^0.14.4"
 plotly = "^6.0.0"
-pymc = "^5.20.0"  # incompatible with numpy 2.x
-numpy = "~1"
+pymc = "^5.20.0"
+numpy = ">=2.0,<3.0"
 scikit-image = "^0.25.1"
 
 

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -67,7 +67,11 @@ def test_temporal_pairwise():
     max_distance = 10.0
 
     results = temporal_pairwise(
-        simulations, time_slices, bw, density=False, max_distance=max_distance
+        point_sets = simulations, 
+        time_slices = time_slices,
+        bw = bw, 
+        use_kde = False, 
+        max_distance = max_distance
     )
 
     # temporal_pairwise returns two objects


### PR DESCRIPTION
I updated the pyproject.toml because it turns out that pymc does work with numpy 2+ now. I then ran the poetry installation and poetry tests. All tests passed. Some warnings came up, though. One was about a call to np.hist within the pairwise_distance funciton. The warning occurs when values in a list of pairwise distances is greater than max_dist---the hist function can't calculate a density properly when values fall outside the bins. So, I added a check that removes any dsitances greater than max_dist before continuing with the density calculations. This only occurs when the user explicitly passes a maximum distance to the function.